### PR TITLE
docs: remove stale AutoGen references after A2A migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
 # Persona Agent
 
-A Python-based API server for creating and interacting with AI personas using the AutoGen framework and Model Context Protocol (MCP) tools integration.
+A Python-based API server for creating and interacting with AI personas using the [Google A2A (Agent-to-Agent) protocol](https://github.com/google/A2A) and Model Context Protocol (MCP) tools integration.
 
 ## Overview
 
-This project provides a robust API for creating AI personas that can interact with users through natural language. Built on top of AutoGen 0.4, it allows for the creation of agents that can use external tools and services through the Model Context Protocol (MCP) to enhance their capabilities.
+This project provides a robust API for creating AI personas that can interact with users through natural language. Built on the Google A2A protocol and the `a2a-sdk`, each persona is exposed as a discoverable A2A agent with standardized agent cards, JSON-RPC messaging, and external tool capabilities via MCP.
 
 ## Features
 
 - **Persona-based AI Agents**: Create and interact with AI agents that simulate specific personas
-- **Model Context Protocol Integration**: Enhance AI capabilities with external tools through MCP
-- **RESTful API**: Provides a comprehensive REST API for managing personas, agents, and conversations
+- **Google A2A Protocol**: Each persona is an A2A-compliant agent with discoverable agent cards and JSON-RPC endpoints
+- **Model Context Protocol Integration**: Enhance AI capabilities with external tools through MCP stdio servers
+- **RESTful API**: Comprehensive REST API for managing personas, agents, and conversations
 - **Tool-Augmented Responses**: Enable agents to use external tools to respond to user queries
-- **Configurable Behavior**: Customize persona characteristics through configuration files
-- **AutoGen 0.4 Support**: Compatible with the latest AutoGen framework features
+- **Configurable Behavior**: Customize persona characteristics through YAML/JSON configuration files
+- **OpenAI-Compatible LLM Support**: Works with any OpenAI-compatible provider (OpenAI, Azure, Ollama, vLLM, etc.)
 
 ## Architecture
 
 The project is organized into several key components:
 
-- **API Server**: FastAPI implementation for the REST API endpoints
+- **API Server**: FastAPI implementation for REST API endpoints and A2A sub-app mounting
+- **A2A Integration**: `PersonaAgentExecutor` implements the A2A executor interface; each persona is mounted as an independent ASSI sub-app
 - **Persona Management**: Load and manage persona definitions from JSON/YAML files
-- **Agent Factory**: Create and configure AutoGen agents based on personas
-- **MCP Integration**: Connect to external MCP services for enhanced capabilities
+- **Agent Factory**: Create and configure persona agents with LLM clients and MCP tools
+- **LLM Client**: Framework-agnostic abstraction using the `openai` SDK directly
+- **MCP Integration**: `DirectMCPManager` for stdio server lifecycle, tool discovery, and execution
 - **Session Management**: Handle conversation sessions between users and agents
 
 ## Installation
@@ -33,18 +36,12 @@ The project is organized into several key components:
    cd persona-agent
    ```
 
-2. Create a virtual environment:
+2. Install dependencies using [uv](https://docs.astral.sh/uv/):
    ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   uv sync
    ```
 
-3. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-4. Configure API keys:
+3. Configure API keys:
    Create a `config/llm_config.json` file with your API keys and model configurations:
    ```json
    {
@@ -58,15 +55,33 @@ The project is organized into several key components:
 
 ### Running the API Server
 
-Start the API server using the provided script:
+Start the API server:
 
 ```bash
-python run_api_server.py
+uv run python run_api_server.py
+# or via CLI
+uv run persona-agent api
 ```
 
 The API will be available at http://localhost:8000/api/v1/ with Swagger documentation at http://localhost:8000/docs.
 
+### CLI Commands
+
+```bash
+uv run persona-agent api              # Start API server
+uv run persona-agent list-personas    # List available personas
+uv run persona-agent agent-card       # Show A2A agent cards
+uv run persona-agent import-persona FILE  # Import persona file
+```
+
 ### API Endpoints
+
+#### A2A Endpoints
+
+- `GET /.well-known/agent.json`: Aggregate agent card for all personas
+- `GET /a2a/{persona_id}/.well-known/agent-card.json`: Individual persona agent card
+- `POST /a2a/{persona_id}/`: A2A JSON-RPC endpoint
+- `GET /a2a/personas`: List all A2A persona agents
 
 #### Personas API
 
@@ -90,7 +105,7 @@ The API will be available at http://localhost:8000/api/v1/ with Swagger document
 - `POST /api/v1/sessions`: Create a new conversation session
 - `DELETE /api/v1/sessions/{id}`: Delete a session
 - `POST /api/v1/sessions/{id}/messages`: Send a message to an agent
-- `GET /api/v1/sessions/{id}/messages`: Get all messages in a session
+- `GET /api/v1/sessions/{id}/events`: Stream session events (SSE)
 
 ### Persona Configuration
 
@@ -154,6 +169,9 @@ persona-agent/
 │   └── personas/            # Example persona definitions
 ├── src/                     # Source code
 │   └── persona_agent/       # Main package
+│       ├── a2a/             # A2A protocol integration
+│       │   ├── agent_card.py    # AgentCard builder
+│       │   └── executor.py      # PersonaAgentExecutor
 │       ├── api/             # API implementation
 │       │   ├── routes/      # API route handlers
 │       │   ├── agent_factory.py # Agent creation factory
@@ -161,14 +179,18 @@ persona-agent/
 │       │   ├── dependencies.py  # FastAPI dependencies
 │       │   ├── models.py    # Pydantic API models
 │       │   ├── persona_manager.py # Persona data management
-│       │   └── server.py    # FastAPI server
+│       │   └── server.py    # FastAPI server + A2A registry
 │       ├── core/            # Core functionality
+│       │   └── persona_profile.py # PersonaProfile dataclass
+│       ├── llm/             # LLM client abstraction
+│       │   └── client.py    # OpenAI-compatible client
 │       ├── mcp/             # MCP integration
+│       │   └── direct_mcp.py # Direct MCP stdio manager
 │       └── cli.py           # Command-line interface
 ├── tests/                   # Test suite
 ├── run_api_server.py        # Server startup script
-├── requirements.txt         # Project dependencies
-└── LICENSE                  # License
+├── pyproject.toml           # Project dependencies and metadata
+└── uv.lock                  # Dependency lock file
 ```
 
 ## Development
@@ -180,23 +202,21 @@ persona-agent/
 git clone https://github.com/memenow/persona-agent.git
 cd persona-agent
 
-# Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+# Install dependencies
+uv sync
 
-# Install development dependencies
-pip install -r requirements.txt
-pip install pytest pytest-asyncio black isort mypy
+# Lint and format
+uv run ruff check .
+uv run ruff format .
 
 # Run tests
-pytest
+uv run pytest
 ```
 
 ### Adding New MCP Services
 
-1. Create a new MCP service implementation
-2. Add the service configuration to `config/mcp_config.json`
-3. The service will be automatically loaded by the `McpManager` class
+1. Add the service configuration to `config/mcp_config.json`
+2. The service will be automatically loaded by the `DirectMCPManager` class
 
 ### Extending Personas
 
@@ -205,7 +225,3 @@ To add new persona capabilities:
 1. Enhance the `PersonaProfile` class in `src/persona_agent/core/persona_profile.py`
 2. Update the persona JSON/YAML schema accordingly
 3. Update the API models in `src/persona_agent/api/models.py`
-
-## License
-
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/src/persona_agent/a2a/executor.py
+++ b/src/persona_agent/a2a/executor.py
@@ -1,7 +1,6 @@
 """PersonaAgentExecutor: A2A executor that wraps persona logic with LLM + MCP tools.
 
-Replaces AutoGen's AssistantAgent + UserProxyAgent pattern with a direct
-LLM call loop that handles tool execution internally.
+Uses a direct LLM call loop that handles tool execution internally.
 """
 
 import json

--- a/src/persona_agent/llm/client.py
+++ b/src/persona_agent/llm/client.py
@@ -1,7 +1,7 @@
 """LLM client abstraction with OpenAI-compatible implementation.
 
-Provides a framework-agnostic LLM interface that replaces AutoGen's
-OpenAIChatCompletionClient with direct openai SDK usage.
+Provides a framework-agnostic LLM interface using the openai SDK directly.
+Supports any OpenAI-compatible provider (OpenAI, Azure, Ollama, vLLM, etc.).
 """
 
 import json

--- a/src/persona_agent/mcp/direct_mcp.py
+++ b/src/persona_agent/mcp/direct_mcp.py
@@ -1,7 +1,6 @@
-"""Direct MCP manager using the mcp library without AutoGen wrapper.
+"""MCP manager using the mcp library directly.
 
-Replaces autogen-ext[mcp] with direct mcp library usage for
-stdio server lifecycle, tool discovery, and tool execution.
+Handles stdio server lifecycle, tool discovery, and tool execution.
 """
 
 import json
@@ -73,8 +72,7 @@ class MCPServiceConnection:
 class DirectMCPManager:
     """MCP service and tool manager using the mcp library directly.
 
-    Manages stdio server lifecycle, tool loading, and tool execution
-    without any AutoGen dependency.
+    Manages stdio server lifecycle, tool loading, and tool execution.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
Remove all AutoGen references from README and Python docstrings to reflect the completed migration to Google A2A protocol.

## Related
- Follows up on the A2A migration in `refactor/migrate-autogen-to-a2a`

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| README.md | AutoGen 0.4 framework docs | A2A protocol, a2a-sdk, uv tooling | Full rewrite |
| a2a/executor.py | "Replaces AutoGen's AssistantAgent..." | Current-state docstring | Remove migration comment |
| llm/client.py | "replaces AutoGen's OpenAIChatCompletionClient" | Provider-agnostic description | Remove migration comment |
| mcp/direct_mcp.py | "without AutoGen wrapper" / "Replaces autogen-ext" | Current-state docstring | Remove migration comments |

## Details
### Rewrites README.md for A2A architecture
- Design/Spec: Aligns with CLAUDE.md which already documents A2A architecture
- Implementation notes: Added A2A endpoints, CLI commands, updated project tree, replaced pip/venv with uv
- Reviewer focus: Verify README accuracy against actual endpoints and CLI

### Cleans up Python docstrings
- Implementation notes: Removed all "Replaces AutoGen..." phrasing; docstrings now describe current behavior only
- Reviewer focus: Ensure no useful context was lost

## Testing
- `ruff check` on changed files -- passed
- Manual verification: `grep -ri autogen` -- zero matches

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Documentation-only change, no runtime impact

## Checklist
- [ ] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [ ] Rollout/monitoring considerations noted