### PR TITLE
fix(api): harden runtime config and persona persistence

### DIFF
--- a/config/mcp_config.json
+++ b/config/mcp_config.json
@@ -5,9 +5,6 @@
             "args": [
                 "mcp-server-fetch"
             ],
-            "env": {
-                "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-            },
             "disabled": false,
             "autoApprove": [
                 "fetch"
@@ -15,4 +12,4 @@
             "description": "Web content fetching and conversion for efficient LLM usage"
         }
     }
-} 
+}

--- a/src/persona_agent/api/agent_factory.py
+++ b/src/persona_agent/api/agent_factory.py
@@ -85,7 +85,9 @@ class AgentFactory:
 
         # MCP manager — injected or None (lazy init)
         self._mcp_manager = mcp_manager
-        self._mcp_initialized = False
+        self._mcp_initialized = bool(
+            self._mcp_manager is not None and self._mcp_manager.is_initialized
+        )
 
     def _create_llm_client(self) -> LLMClient:
         """Create LLM client from configuration file."""
@@ -101,6 +103,10 @@ class AgentFactory:
     async def _ensure_mcp(self) -> DirectMCPManager | None:
         """Ensure MCP manager is initialized."""
         if self._mcp_initialized:
+            return self._mcp_manager
+
+        if self._mcp_manager is not None and self._mcp_manager.is_initialized:
+            self._mcp_initialized = True
             return self._mcp_manager
 
         if not self.llm_config_path:

--- a/src/persona_agent/api/config.py
+++ b/src/persona_agent/api/config.py
@@ -22,6 +22,7 @@ ENV_API_KEY_HEADER = "API_KEY_HEADER"
 ENV_API_ALLOWED_KEYS = "API_ALLOWED_KEYS"
 ENV_API_ENABLE_CORS = "API_ENABLE_CORS"
 ENV_API_ALLOWED_ORIGINS = "API_ALLOWED_ORIGINS"
+ENV_API_PUBLIC_BASE_URL = "API_PUBLIC_BASE_URL"
 ENV_PERSONAS_DIR = "PERSONAS_DIR"
 ENV_LLM_CONFIG_PATH = "LLM_CONFIG_PATH"
 ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
@@ -52,6 +53,7 @@ class ApiConfig(BaseModel):
         default_model: Default LLM model to use for agents.
         openai_api_key: Optional OpenAI API key.
         openai_api_base: Optional custom OpenAI API base URL.
+        public_base_url: Optional externally reachable API base URL.
     """
 
     host: str = Field(
@@ -78,6 +80,10 @@ class ApiConfig(BaseModel):
     enable_cors: bool = Field(default=True, description="Enable CORS")
     allowed_origins: list[str] = Field(
         default=["*"], description="Allowed origins for CORS"
+    )
+    public_base_url: str | None = Field(
+        default=None,
+        description="Externally reachable API base URL used in discovery metadata",
     )
 
     # Persona settings
@@ -150,6 +156,7 @@ def load_config() -> ApiConfig:
         enable_cors=os.environ.get(ENV_API_ENABLE_CORS, "").lower()
         not in ("false", "0", "no"),
         allowed_origins=os.environ.get(ENV_API_ALLOWED_ORIGINS, "*").split(","),
+        public_base_url=os.environ.get(ENV_API_PUBLIC_BASE_URL),
         personas_dir=os.environ.get(ENV_PERSONAS_DIR, ApiConfig().personas_dir),
         llm_config_path=os.environ.get(
             ENV_LLM_CONFIG_PATH, ApiConfig().llm_config_path

--- a/src/persona_agent/api/persona_manager.py
+++ b/src/persona_agent/api/persona_manager.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 _PERSONA_ID_PATTERN = r"^[a-z0-9_-]{1,64}$"
 
 
+class PersonaPersistenceError(RuntimeError):
+    """Raised when persisted persona files cannot be updated."""
+
+
 class Persona(BaseModel):
     """Persona model representing a character definition."""
 
@@ -115,6 +119,7 @@ class PersonaManager:
     def __init__(self, personas_dir: str):
         self.personas_dir = personas_dir
         self.personas: dict[str, Persona] = {}
+        self._persona_files: dict[str, set[str]] = {}
         self._load_personas()
 
     def _load_personas(self) -> None:
@@ -134,6 +139,7 @@ class PersonaManager:
                     persona = self._load_persona_file(file_path)
                     if persona:
                         self.personas[persona.id] = persona
+                        self._persona_files.setdefault(persona.id, set()).add(file_path)
                 except Exception as e:
                     logger.warning("Error loading persona from %s: %s", file_path, e)
 
@@ -227,8 +233,31 @@ class PersonaManager:
         if persona_id not in self.personas:
             return False
 
+        try:
+            self._delete_persona_files(persona_id)
+        except OSError as exc:
+            logger.exception("Error deleting persona files for %s", persona_id)
+            raise PersonaPersistenceError(
+                f"Error deleting persona files for {persona_id}"
+            ) from exc
+
         del self.personas[persona_id]
         return True
+
+    def _delete_persona_files(self, persona_id: str) -> None:
+        """Delete persisted files associated with a persona."""
+        root = os.path.abspath(self.personas_dir)
+        candidates = set(self._persona_files.get(persona_id, set()))
+
+        for file_path in candidates:
+            abs_path = os.path.abspath(file_path)
+            if os.path.commonpath([root, abs_path]) != root:
+                logger.warning("Skipping persona file outside personas_dir: %s", file_path)
+                continue
+            if os.path.isfile(abs_path):
+                os.remove(abs_path)
+
+        self._persona_files.pop(persona_id, None)
 
     def save_persona(self, persona: Persona, format: str = "json") -> str:
         """Save a persona to a file."""
@@ -257,4 +286,5 @@ class PersonaManager:
             else:
                 yaml.dump(persona.model_dump(), f, default_flow_style=False)
 
+        self._persona_files.setdefault(persona.id, set()).add(file_path)
         return file_path

--- a/src/persona_agent/api/routes/persona.py
+++ b/src/persona_agent/api/routes/persona.py
@@ -14,6 +14,7 @@ from persona_agent.api.models import (
     SuccessResponse,
     UpdatePersonaRequest,
 )
+from persona_agent.api.persona_manager import PersonaPersistenceError
 
 router = APIRouter(prefix="/personas", tags=["personas"])
 
@@ -140,7 +141,12 @@ async def update_persona(
 )
 async def delete_persona(persona_id: str, persona_manager=Depends(get_persona_manager)):
     """Delete a persona."""
-    if not persona_manager.delete_persona(persona_id):
+    try:
+        deleted = persona_manager.delete_persona(persona_id)
+    except PersonaPersistenceError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    if not deleted:
         raise HTTPException(
             status_code=404, detail=f"Persona with ID {persona_id} not found"
         )

--- a/src/persona_agent/api/server.py
+++ b/src/persona_agent/api/server.py
@@ -38,6 +38,20 @@ logging.basicConfig(
 logger = logging.getLogger("api_server")
 
 
+def _resolve_public_base_url(config: ApiConfig) -> str:
+    """Return the externally reachable base URL for discovery metadata."""
+    if config.public_base_url:
+        return config.public_base_url.rstrip("/")
+
+    host = config.host
+    if host in ("0.0.0.0", "::", ""):
+        host = "localhost"
+    elif ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    return f"http://{host}:{config.port}"
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage MCP service lifecycle and A2A registry setup."""
@@ -59,7 +73,7 @@ async def lifespan(app: FastAPI):
     # Set up A2A registry with all loaded personas
     persona_manager: PersonaManager = app.state.persona_manager
     llm_client = app.state.llm_client
-    registry = A2ARegistry(base_url=f"http://{config.host}:{config.port}")
+    registry = A2ARegistry(base_url=_resolve_public_base_url(config))
 
     for p_info in persona_manager.list_personas():
         p = persona_manager.get_persona(p_info["id"])

--- a/src/persona_agent/llm/client.py
+++ b/src/persona_agent/llm/client.py
@@ -124,16 +124,22 @@ class OpenAICompatibleClient(LLMClient):
         # Find the config matching default_model, fall back to first entry
         matched = {}
         for mc in model_configs:
-            if mc.get("model") == default_model:
+            if mc.get("model") == default_model or mc.get("name") == default_model:
                 matched = mc
                 break
         if not matched and model_configs:
             matched = model_configs[0]
 
+        env_base_url = os.environ.get("OPENAI_BASE_URL") or os.environ.get(
+            "OPENAI_API_BASE"
+        )
+
         return cls(
-            model=matched.get("model", default_model),
-            api_key=matched.get("api_key") or config.get("api_key"),
-            base_url=config.get("api_base"),
+            model=matched.get("model") or matched.get("name", default_model),
+            api_key=os.environ.get("OPENAI_API_KEY")
+            or matched.get("api_key")
+            or config.get("api_key"),
+            base_url=env_base_url or matched.get("api_base") or config.get("api_base"),
             temperature=matched.get("temperature", 0.7),
             max_tokens=matched.get("max_tokens", 4000),
         )

--- a/src/persona_agent/llm/client.py
+++ b/src/persona_agent/llm/client.py
@@ -136,9 +136,7 @@ class OpenAICompatibleClient(LLMClient):
 
         return cls(
             model=matched.get("model") or matched.get("name", default_model),
-            api_key=os.environ.get("OPENAI_API_KEY")
-            or matched.get("api_key")
-            or config.get("api_key"),
+            api_key=matched.get("api_key") or config.get("api_key"),
             base_url=env_base_url or matched.get("api_base") or config.get("api_base"),
             temperature=matched.get("temperature", 0.7),
             max_tokens=matched.get("max_tokens", 4000),

--- a/src/persona_agent/mcp/direct_mcp.py
+++ b/src/persona_agent/mcp/direct_mcp.py
@@ -124,10 +124,16 @@ class DirectMCPManager:
                 logger.warning("No command for MCP service: %s", name)
                 continue
 
-            # Substitute environment variables in command and args
+            # Substitute environment variables in command, args, and env values.
             command = self._substitute_env_vars(command)
             args = [self._substitute_env_vars(a) for a in server_config.get("args", [])]
-            env = server_config.get("env", {})
+            raw_env = server_config.get("env", {})
+            env = {
+                key: self._substitute_env_vars(value)
+                if isinstance(value, str)
+                else str(value)
+                for key, value in raw_env.items()
+            }
 
             if await self._connect_service(name, command, args, env):
                 success = True

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -195,6 +195,28 @@ def test_llm_env_api_base_overrides_config(monkeypatch) -> None:
     assert str(client._client.base_url) == "https://env.example/v1/"
 
 
+def test_llm_model_api_key_overrides_global_openai_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "global-openai-key")
+
+    client = OpenAICompatibleClient.from_config(
+        {
+            "default_model": "provider-a",
+            "api_key": "top-key",
+            "api_base": "https://top.example/v1",
+            "model_configs": [
+                {
+                    "model": "provider-a",
+                    "api_key": "provider-a-key",
+                    "api_base": "https://provider-a.example/v1",
+                }
+            ],
+        }
+    )
+
+    assert client._client.api_key == "provider-a-key"
+    assert str(client._client.base_url) == "https://provider-a.example/v1/"
+
+
 def test_public_base_url_uses_explicit_config() -> None:
     config = ApiConfig(
         host="0.0.0.0",

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,257 @@
+"""Regression tests for configuration and persistence fixes."""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from persona_agent.api.agent_factory import AgentFactory
+from persona_agent.api.config import ApiConfig, load_config
+from persona_agent.api.dependencies import get_persona_manager
+from persona_agent.api.persona_manager import PersonaManager
+from persona_agent.api.routes import persona as persona_routes
+from persona_agent.api.server import _resolve_public_base_url, create_app
+from persona_agent.llm.client import OpenAICompatibleClient
+from persona_agent.mcp.direct_mcp import DirectMCPManager
+
+
+class CapturingMCPManager(DirectMCPManager):
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured_env: dict[str, str] = {}
+
+    async def _connect_service(
+        self,
+        name: str,
+        command: str,
+        args: list[str],
+        env: dict[str, str],
+    ) -> bool:
+        self.captured_env = env
+        return True
+
+
+async def test_mcp_config_substitutes_env_values(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("BRAVE_API_KEY", "real-key")
+    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin")
+    config_path = tmp_path / "mcp_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "brave": {
+                        "command": "node",
+                        "args": ["server.js"],
+                        "env": {
+                            "BRAVE_API_KEY": "${BRAVE_API_KEY}",
+                            "PATH": "${PATH}:/opt/mcp/bin",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = CapturingMCPManager()
+    assert await manager.load_config(str(config_path)) is True
+    assert manager.captured_env == {
+        "BRAVE_API_KEY": "real-key",
+        "PATH": "/usr/local/bin:/usr/bin:/opt/mcp/bin",
+    }
+
+
+def test_default_mcp_config_does_not_override_path() -> None:
+    config = json.loads(Path("config/mcp_config.json").read_text(encoding="utf-8"))
+    service = config["mcpServers"]["mcp-server-fetch"]
+    assert "PATH" not in service.get("env", {})
+
+
+async def test_agent_factory_reuses_initialized_injected_mcp_manager(tmp_path) -> None:
+    llm_config_path = tmp_path / "llm_config.json"
+    llm_config_path.write_text("{}", encoding="utf-8")
+    mcp_manager = MagicMock()
+    mcp_manager.is_initialized = True
+    mcp_manager.load_config = AsyncMock()
+
+    factory = AgentFactory(
+        llm_config_path=str(llm_config_path),
+        llm_client=MagicMock(),
+        mcp_manager=mcp_manager,
+    )
+
+    assert await factory._ensure_mcp() is mcp_manager
+    mcp_manager.load_config.assert_not_awaited()
+
+
+def test_delete_persona_removes_loaded_file(tmp_path) -> None:
+    persona_file = tmp_path / "alice.yaml"
+    persona_file.write_text(
+        "id: alice\nname: Alice\ndescription: Example persona\n",
+        encoding="utf-8",
+    )
+    manager = PersonaManager(str(tmp_path))
+
+    assert manager.delete_persona("alice") is True
+    assert not persona_file.exists()
+    assert PersonaManager(str(tmp_path)).get_persona("alice") is None
+
+
+def test_delete_persona_does_not_remove_file_for_different_declared_id(tmp_path) -> None:
+    aliased_file = tmp_path / "alice.yaml"
+    aliased_file.write_text(
+        "id: bob\nname: Bob\ndescription: Stored in alice.yaml\n",
+        encoding="utf-8",
+    )
+    filename_match_file = tmp_path / "bob.yaml"
+    filename_match_file.write_text(
+        "id: carol\nname: Carol\ndescription: Stored in bob.yaml\n",
+        encoding="utf-8",
+    )
+    manager = PersonaManager(str(tmp_path))
+
+    assert manager.delete_persona("bob") is True
+
+    assert not aliased_file.exists()
+    assert filename_match_file.exists()
+    reloaded = PersonaManager(str(tmp_path))
+    assert reloaded.get_persona("bob") is None
+    assert reloaded.get_persona("carol") is not None
+
+
+def test_delete_persona_failure_returns_500_and_keeps_state(tmp_path, monkeypatch) -> None:
+    persona_file = tmp_path / "alice.yaml"
+    persona_file.write_text(
+        "id: alice\nname: Alice\ndescription: Example persona\n",
+        encoding="utf-8",
+    )
+    manager = PersonaManager(str(tmp_path))
+
+    def fail_remove(path: str) -> None:
+        raise OSError(f"cannot remove {path}")
+
+    monkeypatch.setattr("persona_agent.api.persona_manager.os.remove", fail_remove)
+
+    app = FastAPI()
+    app.dependency_overrides[get_persona_manager] = lambda: manager
+    app.include_router(persona_routes.router, prefix="/api/v1")
+
+    response = TestClient(app).delete("/api/v1/personas/alice")
+
+    assert response.status_code == 500
+    assert manager.get_persona("alice") is not None
+    assert str(persona_file) in manager._persona_files["alice"]  # noqa: SLF001
+
+
+def test_llm_model_config_api_base_overrides_top_level() -> None:
+    client = OpenAICompatibleClient.from_config(
+        {
+            "default_model": "provider-b",
+            "api_key": "top-key",
+            "api_base": "https://top.example/v1",
+            "model_configs": [
+                {
+                    "model": "provider-b",
+                    "api_base": "https://provider-b.example/v1",
+                    "api_key": "model-key",
+                }
+            ],
+        }
+    )
+
+    assert str(client._client.base_url) == "https://provider-b.example/v1/"
+
+
+def test_llm_api_base_falls_back_to_top_level() -> None:
+    client = OpenAICompatibleClient.from_config(
+        {
+            "default_model": "provider-a",
+            "api_key": "top-key",
+            "api_base": "https://top.example/v1",
+            "model_configs": [{"model": "provider-a"}],
+        }
+    )
+
+    assert str(client._client.base_url) == "https://top.example/v1/"
+
+
+def test_llm_env_api_base_overrides_config(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://env.example/v1")
+
+    client = OpenAICompatibleClient.from_config(
+        {
+            "default_model": "provider-a",
+            "api_key": "top-key",
+            "api_base": "https://top.example/v1",
+            "model_configs": [
+                {"model": "provider-a", "api_base": "https://model.example/v1"}
+            ],
+        }
+    )
+
+    assert str(client._client.base_url) == "https://env.example/v1/"
+
+
+def test_public_base_url_uses_explicit_config() -> None:
+    config = ApiConfig(
+        host="0.0.0.0",
+        port=8000,
+        public_base_url="https://agents.example.com/root/",
+    )
+
+    assert _resolve_public_base_url(config) == "https://agents.example.com/root"
+
+
+def test_public_base_url_never_publishes_wildcard_bind_host() -> None:
+    config = ApiConfig(host="0.0.0.0", port=8000)
+
+    assert _resolve_public_base_url(config) == "http://localhost:8000"
+
+
+def test_load_config_reads_api_public_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("API_PUBLIC_BASE_URL", "https://agents.example.com")
+
+    assert load_config().public_base_url == "https://agents.example.com"
+
+
+def test_a2a_routes_use_public_base_url(tmp_path) -> None:
+    personas_dir = tmp_path / "personas"
+    personas_dir.mkdir()
+    (personas_dir / "alice.yaml").write_text(
+        "id: alice\nname: Alice\ndescription: Example persona\n",
+        encoding="utf-8",
+    )
+    llm_config_path = tmp_path / "llm_config.json"
+    llm_config_path.write_text(
+        json.dumps({"default_model": "gpt-4o-mini", "api_key": ""}),
+        encoding="utf-8",
+    )
+
+    app = asyncio.run(
+        create_app(
+            ApiConfig(
+                host="0.0.0.0",
+                port=8000,
+                public_base_url="https://agents.example.com",
+                personas_dir=str(personas_dir),
+                llm_config_path=str(llm_config_path),
+                mcp_config_path=str(tmp_path / "missing_mcp_config.json"),
+            )
+        )
+    )
+
+    with TestClient(app) as client:
+        aggregate = client.get("/.well-known/agent.json")
+        listing = client.get("/a2a/personas")
+        card = client.get("/a2a/alice/.well-known/agent-card.json")
+
+    assert aggregate.status_code == 200
+    assert listing.status_code == 200
+    assert card.status_code == 200
+    assert aggregate.json()["url"] == "https://agents.example.com/a2a/"
+    assert listing.json()["agents"][0]["url"] == "https://agents.example.com/a2a/alice/"
+    assert card.json()["url"] == "https://agents.example.com/a2a/alice/"
+    assert "0.0.0.0" not in aggregate.text + listing.text + card.text


### PR DESCRIPTION
## Summary
Harden runtime configuration handling and persona persistence so MCP tools, OpenAI-compatible providers, A2A discovery, and persona deletion behave correctly across deployment configurations.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| MCP configuration | Environment substitutions skipped `env` values and default config overrode `PATH` | `env` values are expanded and default config inherits the process `PATH` | Prevents broken stdio MCP servers on Linux and custom installations |
| MCP manager lifecycle | REST agent creation could reload or drop an already initialized manager | Injected initialized managers are reused | Avoids duplicate tool registration and missing tools |
| Persona persistence | Delete removed only memory state or could delete filename-matched files for another persona | Delete removes only files explicitly associated with the persona and reports persistence failures as 500 | Keeps deletion durable without removing unrelated persona files |
| LLM provider configuration | Only top-level `api_base` was used | Environment, model-level, then top-level base URL precedence is supported while preserving model-specific API keys | Supports multiple OpenAI-compatible providers |
| A2A discovery URL | Agent cards could publish `0.0.0.0` | `API_PUBLIC_BASE_URL` is supported and wildcard bind hosts fall back to localhost | Produces reachable discovery metadata |

## Details
### Updates MCP configuration from partial substitution to complete substitution
- Design/Spec: Environment variables in MCP configuration should resolve consistently across command, args, and env entries.
- Implementation notes: `DirectMCPManager.load_config()` now expands env values before merging with the process environment; the default MCP config no longer sets a platform-specific `PATH`.
- Reviewer focus: Confirm missing variables preserve existing empty-string substitution behavior.

### Updates MCP manager lifecycle from eager reload to reuse
- Design/Spec: A shared manager initialized during app lifespan should be reused by REST-created agents.
- Implementation notes: `AgentFactory` now checks the injected manager's `is_initialized` state before deriving and loading another config path.
- Reviewer focus: Confirm initialized injected managers do not call `load_config()` again.

### Updates persona persistence from memory-only deletion to durable deletion
- Design/Spec: Deleting a persona should remove the persona's persisted files without deleting files belonging to other personas.
- Implementation notes: `PersonaManager` records associated file paths on load/save and deletes only those recorded paths; persistence failures raise `PersonaPersistenceError` and map to HTTP 500.
- Reviewer focus: Confirm filename/id mismatches do not cause unrelated persona files to be deleted.

### Updates LLM provider config from top-level only to provider-specific precedence
- Design/Spec: OpenAI-compatible providers may require per-model base URLs and provider-specific credentials.
- Implementation notes: `OpenAICompatibleClient.from_config()` now matches by `model` or `name`, resolves base URL via environment, matched model config, then top-level config, and preserves model-level API keys over the global `OPENAI_API_KEY` fallback.
- Reviewer focus: Confirm existing top-level-only configs still work and multi-provider configs do not mix provider URLs with the wrong credential.

### Updates A2A discovery from bind URL to public URL
- Design/Spec: Agent cards should advertise externally reachable URLs, not bind-only hosts.
- Implementation notes: `API_PUBLIC_BASE_URL` / `public_base_url` is used when provided; `0.0.0.0`, `::`, and empty bind hosts fall back to localhost.
- Reviewer focus: Confirm deployment docs or env configuration can set the public URL when behind a proxy.

## Testing
- `uv run pytest -q && uv run ruff check .` — 39 passed; Ruff passed
- Manual steps: Not run

## Screenshots / Notes
Not applicable

## Breaking changes
Not applicable

## Risks and rollout
- Existing deployments using `API_HOST=0.0.0.0` without `API_PUBLIC_BASE_URL` will publish localhost in agent cards — set `API_PUBLIC_BASE_URL` to the externally reachable origin in container or proxy deployments.
- Persona deletion now depends on tracked loaded/saved file associations — covered by regression tests for loaded files, filename/id mismatches, and deletion failures.
- Multi-provider LLM configurations can include provider-specific credentials — covered by a regression test that keeps model-level API keys ahead of the global `OPENAI_API_KEY` fallback.

## Checklist
- [ ] Tests added/updated if needed
- [ ] Docs updated if needed
- [ ] Backward compatibility considered
- [ ] Rollout/monitoring considerations noted