### PR TITLE
fix(api): close P0 review findings (timestamps, leaks, auth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ CLAUDE.local.md
 
 # Serena MCP project state
 .serena/
+.gitnexus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,47 @@ Fork-based: `origin` is your fork, `upstream` is `memenow/persona-agent`. PR to 
 - Python with type hints throughout
 - PEP 8 conventions
 - Use `ruff` for linting and formatting
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **persona-agent** (737 symbols, 1116 relationships, 12 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/persona-agent/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/persona-agent/clusters` | All functional areas |
+| `gitnexus://repo/persona-agent/processes` | All execution flows |
+| `gitnexus://repo/persona-agent/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/src/persona_agent/api/agent_factory.py
+++ b/src/persona_agent/api/agent_factory.py
@@ -40,7 +40,10 @@ class AgentSession:
         self.agent_id: str = agent_id
         self.persona_id: str = persona_id
         self.executor: PersonaAgentExecutor = executor
-        self.created_at: float = time.monotonic()
+        # Wall-clock seconds — exposed as ``created_at`` / ``last_active`` on the
+        # API surface, so clients can correlate with message timestamps recorded
+        # by ``PersonaAgentExecutor``.
+        self.created_at: float = time.time()
         self.last_active: float = self.created_at
 
     @property
@@ -161,7 +164,7 @@ class AgentFactory:
             "id": agent_id,
             "persona_id": persona.id,
             "executor": executor,
-            "created_at": time.monotonic(),
+            "created_at": time.time(),
         }
 
         logger.info("Created agent %s for persona %s", agent_id, persona.name)
@@ -266,9 +269,9 @@ class AgentFactory:
             if not response:
                 return False, "Failed to get response from agent"
 
-            session.last_active = time.monotonic()
+            session.last_active = time.time()
             return True, response
 
-        except Exception as e:
+        except Exception:
             logger.exception("Error in send_message")
-            return False, f"Error: {e}"
+            return False, "Error processing message"

--- a/src/persona_agent/api/auth.py
+++ b/src/persona_agent/api/auth.py
@@ -1,6 +1,7 @@
 """API key authentication dependency."""
 
 import logging
+import secrets
 from collections.abc import Callable
 from typing import Annotated
 
@@ -21,6 +22,11 @@ def make_api_key_dependency(config: ApiConfig) -> Callable:
     unauthenticated callers continue to work in dev. Construction time
     binds the security scheme to the active ``config.api_key_header``,
     so renaming the header takes effect on app restart.
+
+    Comparison uses :func:`secrets.compare_digest` over every configured key
+    so a timing side-channel cannot reveal which prefix matched. Empty
+    allowlist entries are skipped defensively in case ``load_config``'s
+    blank-key filter is ever bypassed.
     """
 
     api_key_scheme = APIKeyHeader(name=config.api_key_header, auto_error=False)
@@ -34,7 +40,15 @@ def make_api_key_dependency(config: ApiConfig) -> Callable:
                 "enable_auth=True but allowed_api_keys is empty; refusing all requests"
             )
             raise HTTPException(status_code=503, detail="Authentication misconfigured")
-        if api_key_header is None or api_key_header not in config.allowed_api_keys:
+        if not api_key_header:
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        matched = False
+        for allowed in config.allowed_api_keys:
+            if not allowed:
+                continue
+            if secrets.compare_digest(api_key_header, allowed):
+                matched = True
+        if not matched:
             raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
     return verify_api_key

--- a/src/persona_agent/api/config.py
+++ b/src/persona_agent/api/config.py
@@ -150,9 +150,14 @@ def load_config() -> ApiConfig:
         enable_auth=os.environ.get(ENV_API_ENABLE_AUTH, "").lower()
         in ("true", "1", "yes"),
         api_key_header=os.environ.get(ENV_API_KEY_HEADER, "X-API-Key"),
-        allowed_api_keys=os.environ.get(ENV_API_ALLOWED_KEYS, "").split(",")
-        if os.environ.get(ENV_API_ALLOWED_KEYS)
-        else [],
+        allowed_api_keys=[
+            key
+            for key in (
+                raw.strip()
+                for raw in os.environ.get(ENV_API_ALLOWED_KEYS, "").split(",")
+            )
+            if key
+        ],
         enable_cors=os.environ.get(ENV_API_ENABLE_CORS, "").lower()
         not in ("false", "0", "no"),
         allowed_origins=os.environ.get(ENV_API_ALLOWED_ORIGINS, "*").split(","),

--- a/src/persona_agent/api/routes/agent.py
+++ b/src/persona_agent/api/routes/agent.py
@@ -1,5 +1,7 @@
 """API routes for agent management."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from persona_agent.api.dependencies import get_agent_factory, get_persona_manager
@@ -9,6 +11,8 @@ from persona_agent.api.models import (
     CreateAgentRequest,
     SuccessResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -94,7 +98,8 @@ async def create_agent(
             created_at=agent_info["created_at"],
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error creating agent: {e}") from e
+        logger.exception("Error creating agent for persona %s", request.persona_id)
+        raise HTTPException(status_code=500, detail="Error creating agent") from e
 
 
 @router.delete(

--- a/src/persona_agent/api/routes/persona.py
+++ b/src/persona_agent/api/routes/persona.py
@@ -1,6 +1,7 @@
 """API routes for persona management."""
 
 import json
+import logging
 
 import yaml
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
@@ -15,6 +16,8 @@ from persona_agent.api.models import (
     UpdatePersonaRequest,
 )
 from persona_agent.api.persona_manager import PersonaPersistenceError
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/personas", tags=["personas"])
 
@@ -83,7 +86,8 @@ async def create_persona(
     try:
         persona_manager.save_persona(new_persona, format="json")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error saving persona: {e}") from e
+        logger.exception("Error saving persona %s", new_persona.id)
+        raise HTTPException(status_code=500, detail="Error saving persona") from e
 
     return PersonaResponse(
         id=new_persona.id, name=new_persona.name, description=new_persona.description
@@ -124,7 +128,8 @@ async def update_persona(
     try:
         persona_manager.save_persona(updated_persona, format="json")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error saving persona: {e}") from e
+        logger.exception("Error saving persona %s", updated_persona.id)
+        raise HTTPException(status_code=500, detail="Error saving persona") from e
 
     return PersonaResponse(
         id=updated_persona.id,
@@ -192,9 +197,8 @@ async def upload_persona(
         try:
             persona_manager.save_persona(new_persona, format="json")
         except Exception as e:
-            raise HTTPException(
-                status_code=500, detail=f"Error saving persona: {e}"
-            ) from e
+            logger.exception("Error saving uploaded persona %s", new_persona.id)
+            raise HTTPException(status_code=500, detail="Error saving persona") from e
 
         return PersonaResponse(
             id=new_persona.id,
@@ -206,6 +210,5 @@ async def upload_persona(
     except yaml.YAMLError:
         raise HTTPException(status_code=400, detail="Invalid YAML file") from None
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error processing file: {str(e)}"
-        ) from e
+        logger.exception("Error processing uploaded persona file %s", file.filename)
+        raise HTTPException(status_code=500, detail="Error processing file") from e

--- a/src/persona_agent/api/routes/session.py
+++ b/src/persona_agent/api/routes/session.py
@@ -178,10 +178,10 @@ async def send_message(
         return SendMessageResponse(
             session_id=session_id, success=success, response=response
         )
-    except Exception as e:
+    except Exception:
         logger.exception("Error sending message in session %s", session_id)
         return SendMessageResponse(
             session_id=session_id,
             success=False,
-            response=f"Error processing message: {e}",
+            response="Error processing message",
         )

--- a/src/persona_agent/api/server.py
+++ b/src/persona_agent/api/server.py
@@ -226,12 +226,17 @@ async def create_app(config: ApiConfig | None = None) -> FastAPI:
 
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception):
-        import traceback
-
-        logger.error("Unhandled exception: %s\n%s", exc, traceback.format_exc())
+        # Never echo ``str(exc)`` to clients — raw exception messages can carry
+        # local paths, secrets, or internal type names. Log with traceback and
+        # return a stable, non-revealing payload instead.
+        logger.exception(
+            "Unhandled exception while processing %s %s",
+            request.method,
+            request.url.path,
+        )
         return JSONResponse(
             status_code=500,
-            content={"detail": "Internal server error", "message": str(exc)},
+            content={"detail": "Internal server error"},
         )
 
     return app

--- a/tests/test_p0_fixes.py
+++ b/tests/test_p0_fixes.py
@@ -1,0 +1,117 @@
+"""Regression tests for the P0 review findings.
+
+Coverage:
+
+* ``AgentSession`` exposes Unix wall-clock timestamps so REST clients can
+  compare them against message ``timestamp`` values written by the executor.
+* The global exception handler does not echo ``str(exc)`` to clients.
+* ``load_config`` filters blank entries from ``API_ALLOWED_KEYS`` so a
+  trailing comma cannot inject an empty allow-listed key.
+* ``make_api_key_dependency`` uses constant-time comparison and refuses an
+  empty header even if a blank entry slips into the allow list.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from persona_agent.api.agent_factory import AgentSession
+from persona_agent.api.auth import make_api_key_dependency
+from persona_agent.api.config import ApiConfig, load_config
+from persona_agent.api.dependencies import clear_dependency_caches
+from persona_agent.api.server import create_app
+
+
+def test_agent_session_timestamps_are_wall_clock_seconds() -> None:
+    executor = MagicMock()
+    before = time.time()
+    session = AgentSession(agent_id="a", persona_id="p", executor=executor)
+    after = time.time()
+    assert before <= session.created_at <= after
+    assert before <= session.last_active <= after
+
+
+async def test_global_exception_handler_does_not_leak_str_exc(tmp_path) -> None:
+    from fastapi.testclient import TestClient
+
+    personas_dir = tmp_path / "personas"
+    personas_dir.mkdir()
+    llm_config_path = tmp_path / "llm_config.json"
+    llm_config_path.write_text("{}", encoding="utf-8")
+    cfg = ApiConfig(
+        host="127.0.0.1",
+        port=8000,
+        personas_dir=str(personas_dir),
+        llm_config_path=str(llm_config_path),
+        mcp_config_path=str(tmp_path / "missing_mcp_config.json"),
+    )
+    app = await create_app(cfg)
+
+    secret_marker = "SUPER-SECRET-INTERNAL-DETAIL"
+
+    @app.get("/__boom")
+    async def boom() -> None:
+        raise RuntimeError(secret_marker)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/__boom")
+
+    assert response.status_code == 500
+    assert secret_marker not in response.text
+    assert response.json() == {"detail": "Internal server error"}
+
+
+def test_load_config_filters_blank_allowed_api_keys(monkeypatch) -> None:
+    monkeypatch.setenv("API_ALLOWED_KEYS", "key1, ,,key2,")
+    monkeypatch.delenv("LLM_CONFIG_PATH", raising=False)
+    clear_dependency_caches()
+    try:
+        cfg = load_config()
+    finally:
+        clear_dependency_caches()
+    assert cfg.allowed_api_keys == ["key1", "key2"]
+
+
+def test_load_config_drops_purely_blank_allowed_api_keys(monkeypatch) -> None:
+    monkeypatch.setenv("API_ALLOWED_KEYS", " , , ")
+    monkeypatch.delenv("LLM_CONFIG_PATH", raising=False)
+    clear_dependency_caches()
+    try:
+        cfg = load_config()
+    finally:
+        clear_dependency_caches()
+    assert cfg.allowed_api_keys == []
+
+
+async def test_verify_api_key_rejects_empty_header() -> None:
+    cfg = ApiConfig(enable_auth=True, allowed_api_keys=["secret"])
+    verify = make_api_key_dependency(cfg)
+    with pytest.raises(HTTPException) as exc:
+        await verify(api_key_header="")
+    assert exc.value.status_code == 401
+
+
+async def test_verify_api_key_skips_blank_allowlist_entries() -> None:
+    """Defense-in-depth: even if a blank entry slips past ``load_config``'s
+    filter, the constant-time loop must not authenticate an empty header."""
+    cfg = ApiConfig(enable_auth=True, allowed_api_keys=["", "real-key"])
+    verify = make_api_key_dependency(cfg)
+    with pytest.raises(HTTPException) as exc:
+        await verify(api_key_header="")
+    assert exc.value.status_code == 401
+
+
+async def test_verify_api_key_constant_time_accepts_correct_key() -> None:
+    cfg = ApiConfig(enable_auth=True, allowed_api_keys=["alpha", "beta"])
+    verify = make_api_key_dependency(cfg)
+    await verify(api_key_header="beta")
+
+
+async def test_verify_api_key_constant_time_refuses_wrong_key() -> None:
+    cfg = ApiConfig(enable_auth=True, allowed_api_keys=["alpha", "beta"])
+    verify = make_api_key_dependency(cfg)
+    with pytest.raises(HTTPException) as exc:
+        await verify(api_key_header="gamma")
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
Apply the four P0 fixes surfaced in a recent main-branch review: stop exposing `time.monotonic()` values as Unix timestamps, stop echoing `str(exc)` in error responses, filter blank entries from `API_ALLOWED_KEYS`, and switch API key matching to constant-time comparison. Also adopts repo-level GitNexus indexing conventions.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `AgentSession` timestamps | `time.monotonic()` | `time.time()` | Aligns with executor history wall-clock entries; clients can now correlate session and message timestamps |
| Global error handler | echoed `str(exc)` | `logger.exception` + `{"detail": "Internal server error"}` | Removes leakage of internal paths/secrets via raw exception text |
| `API_ALLOWED_KEYS` parsing | naive `split(",")` | trim + drop blanks | Trailing/duplicate commas no longer inject an empty allow-listed key |
| API key comparison | `in` operator | `secrets.compare_digest` loop, blank-entry skip | Mitigates timing side-channel; defends against blank entries reaching the loop |
| Route-level error responses | `f"Error: {e}"` | `logger.exception` + generic `detail` | Same leakage pattern collapsed across `agent.py`, `persona.py`, `session.py`, and `agent_factory.send_message` |
| Repo tooling (separate commit) | — | GitNexus block in `CLAUDE.md`, `.gitnexus` ignored | Captures pre-existing on-disk state introduced by the local GitNexus index |

## Details
### Updates timestamps from monotonic to wall-clock
- Design/Spec: `AgentSession.created_at` / `last_active` and `agents[*].created_at` are returned in REST responses (`SessionResponse`, `AgentResponse`); they must be Unix seconds so clients can compare them to `MessageResponse.timestamp` (which already uses `time.time()` in `PersonaAgentExecutor`).
- Implementation notes: Replaced three call sites in `agent_factory.py` with `time.time()`; left no monotonic uses on the public surface.
- Reviewer focus: confirm no remaining duration math relies on monotonic semantics for these fields.

### Updates error response hygiene from str(exc) echo to logger + generic detail
- Design/Spec: Internal exception text must not reach the HTTP body. Logger retains the full traceback for ops.
- Implementation notes: `global_exception_handler` now uses `logger.exception` and returns a stable `{"detail": "Internal server error"}` payload. Route handlers in `agent.py`, `persona.py`, `session.py`, and `AgentFactory.send_message` swap their `f"Error: {e}"` shapes for the same logger-plus-generic-detail pattern.
- Reviewer focus: any remaining `str(exc)` or `f"Error: {e}"` patterns in handlers (none found by `rg`).

### Updates API_ALLOWED_KEYS parsing from naive split to trim + filter
- Design/Spec: Empty strings must never enter the allow list; environment misconfiguration (`"k1,"`, `" "`) must result in zero or filtered keys, not a silent vulnerability.
- Implementation notes: list comprehension over `split(",")`, `strip()` each entry, drop falsy.
- Reviewer focus: callers that depend on positional indexing (none — the allow list is only iterated for membership).

### Updates API key comparison from `in` operator to constant-time loop
- Design/Spec: `secrets.compare_digest` per allow-list entry; iterate the full list before deciding to defeat positional timing leakage. Skip blank entries defensively. Reject empty `api_key_header` outright.
- Implementation notes: `make_api_key_dependency` re-implemented; behavior on the documented states (disabled / misconfigured / missing / wrong / correct, plus custom header name) preserved by existing tests.
- Reviewer focus: ensure no production caller depends on the prior short-circuit ordering.

### Updates repo tooling (chore commit)
- Design/Spec: GitNexus indexes the repo; the index directory `.gitnexus` and the auto-injected GitNexus block in `CLAUDE.md` should live under version control alongside any tooling docs.
- Implementation notes: pure docs/ignore additions; no behavior change.
- Reviewer focus: none.

## Testing
- `uv run ruff check .` -- All checks passed
- `uv run ruff format --check` (touched files) -- formatted
- `uv run pytest -q` -- 47 passed (run twice: once before the rebase, once on the rebased branch)
- `mcp__gitnexus__detect_changes` -- changed scope matches plan, no unexpected processes affected

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable. Public API contracts are unchanged; clients that were previously coercing `created_at`/`last_active` into wall-clock time were getting bad data and will now get correct data.

## Risks and rollout
- Constant-time comparison loop iterates the full allow list on every authenticated request. With small allow lists (typical <=10 keys) the cost is negligible. If a deployment grows the allow list into the hundreds, consider hashing keys at config load.
- Error-response hygiene means ops must rely on logs for diagnosis. Existing log infrastructure is unchanged; `logger.exception` carries the traceback.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed (only `CLAUDE.md`; no public docs touched)
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted