### PR TITLE
docs: align LLM credential cascade and fill documentation gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Auth/CORS env: `API_ENABLE_AUTH`, `API_KEY_HEADER`, `API_ALLOWED_KEYS` (CSV, bla
 File env: `PERSONAS_DIR` (default `examples/personas`), `LLM_CONFIG_PATH` (`config/llm_config.json`), `MCP_CONFIG_PATH` (`config/mcp_config.json`).
 LLM env: `OPENAI_API_KEY`, `OPENAI_API_BASE` / `OPENAI_BASE_URL`, `DEFAULT_MODEL`.
 
+LLM credential precedence is field-specific and an exception to the env-first rule above: `api_key` is **file-first** (`OPENAI_API_KEY` is a fallback only when both the per-model and file-level keys are empty), while `api_base` is **env-first** (`OPENAI_BASE_URL` / `OPENAI_API_BASE` win over the file). The active client is built by `OpenAICompatibleClient.from_config()` from `llm_config.json`; `ApiConfig.openai_api_key` / `openai_api_base` are populated for inspection but do not construct the client. `DEFAULT_MODEL` sets `ApiConfig.default_model` (default `gpt-4o`, overridden by the file's `default_model` on load). See `docs/index.html`.
+
 ## A2A Endpoints
 
 - `GET /.well-known/agent.json` — Aggregate agent card for all personas (public).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Auth/CORS env: `API_ENABLE_AUTH`, `API_KEY_HEADER`, `API_ALLOWED_KEYS` (CSV, bla
 File env: `PERSONAS_DIR` (default `examples/personas`), `LLM_CONFIG_PATH` (`config/llm_config.json`), `MCP_CONFIG_PATH` (`config/mcp_config.json`).
 LLM env: `OPENAI_API_KEY`, `OPENAI_API_BASE` / `OPENAI_BASE_URL`, `DEFAULT_MODEL`.
 
+LLM credential precedence is field-specific and an exception to the env-first rule above: `api_key` is **file-first** (`OPENAI_API_KEY` is a fallback only when both the per-model and file-level keys are empty), while `api_base` is **env-first** (`OPENAI_BASE_URL` / `OPENAI_API_BASE` win over the file). The active client is built by `OpenAICompatibleClient.from_config()` from `llm_config.json`; `ApiConfig.openai_api_key` / `openai_api_base` are populated for inspection but do not construct the client. `DEFAULT_MODEL` sets `ApiConfig.default_model` (default `gpt-4o`, overridden by the file's `default_model` on load). See `docs/configuration.html`.
+
 ## A2A Endpoints
 
 - `GET /.well-known/agent.json` — Aggregate agent card for all personas (public).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Set your LLM credentials in `config/llm_config.json` (see
 For a quick start, leave the `api_key` fields empty in the file and
 export `OPENAI_API_KEY`. The LLM client falls back to that environment
 variable only when both the per-model and file-level `api_key` are
-empty — non-empty file values take precedence.
+empty — non-empty file values take precedence. The base URL resolves the
+other way around: `OPENAI_BASE_URL` / `OPENAI_API_BASE` override the
+file's `api_base` when set. See
+[docs/configuration.html](docs/configuration.html) for the full cascade.
 
 ## CLI
 

--- a/docs/a2a-protocol.html
+++ b/docs/a2a-protocol.html
@@ -136,6 +136,11 @@ declares:</p>
 <code>f"{base_url}/a2a/{persona_id}/"</code> where <code>base_url</code>
 is taken from <code>API_PUBLIC_BASE_URL</code> if set, otherwise built
 from <code>API_HOST</code>/<code>API_PORT</code>.</li>
+<li><strong><code>version</code></strong> — the AgentCard version
+string, currently <code>"1.0.0"</code> for both the per-persona and
+aggregate cards. This is the card's own version and is independent of the
+API / package version (<code>0.2.0</code>) reported by
+<code>/health</code>.</li>
 <li><strong><code>capabilities</code></strong> —
 <code>streaming=True</code>, <code>state_transition_history=True</code>,
 <code>push_notifications=False</code>.</li>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -39,6 +39,25 @@ from Markdown to static HTML pages with a shared local stylesheet and
 <li>Maintenance: refreshed code comments and docstrings so they
 emphasize security, concurrency, configuration precedence, and
 persistence invariants without restating obvious code behavior.</li>
+<li>Documentation accuracy: aligned the LLM credential-cascade
+description across the changelog, <code>README.md</code>,
+<code>CLAUDE.md</code>, and <code>AGENTS.md</code> with
+<a href="configuration.html">configuration.html</a> and the shipped
+<code>OpenAICompatibleClient.from_config()</code> behavior —
+<code>api_key</code> resolves file-first
+(<code>OPENAI_API_KEY</code> is a fallback only) and
+<code>api_base</code> resolves env-first
+(<code>OPENAI_BASE_URL</code> / <code>OPENAI_API_BASE</code>). Clarified in
+<code>api/config.py</code> that <code>ApiConfig.openai_api_key</code> /
+<code>openai_api_base</code> are populated for inspection only and do not
+build the client.</li>
+<li>Documentation completeness: documented the AgentCard
+<code>version</code> (<code>"1.0.0"</code>, independent of the
+<code>0.2.0</code> API version) in
+<a href="a2a-protocol.html">a2a-protocol.html</a>, and noted in
+<a href="persona-schema.html">persona-schema.html</a> that
+<code>system_prompt</code> is not echoed by the persona detail
+endpoint.</li>
 </ul>
 <h2 id="pr-9-17112b6">0.2.0 (PR #9 — <code>17112b6</code>)</h2>
 <p>P0 review follow-ups closing the last batch of API hardening
@@ -67,12 +86,16 @@ separator can no longer admit an empty key.</li>
 <h2 id="pr-8-96baf48">PR #8 — <code>96baf48</code></h2>
 <p>Runtime config and persona persistence hardening.</p>
 <ul>
-<li><strong>LLM credential cascade</strong>: <code>load_config</code>
-reads <code>default_model</code> first, then loads
-<code>api_key</code>/<code>api_base</code> from the matching
-<code>model_configs</code> entry, with environment overrides winning. A
-global file-level <code>api_key</code> no longer overrides a per-model
-key.</li>
+<li><strong>LLM credential cascade</strong>: the
+<code>model_configs</code> entry matching <code>default_model</code>
+became the primary source of <code>api_key</code> and
+<code>api_base</code>, so a global file-level <code>api_key</code> no
+longer overrides a per-model key. The two credentials resolve on
+different cascades (see <a href="configuration.html">configuration.html</a>):
+<code>api_key</code> is file-first — <code>OPENAI_API_KEY</code> is only a
+fallback when both the per-model and file-level values are empty — while
+<code>api_base</code> is env-first, with <code>OPENAI_BASE_URL</code> /
+<code>OPENAI_API_BASE</code> winning when set.</li>
 <li><strong><code>save_persona</code> re-validation</strong>:
 <code>Persona.save_persona</code> re-checks the ID regex and rejects
 path-traversal patterns (<code>..</code>, <code>/</code>,

--- a/docs/persona-schema.html
+++ b/docs/persona-schema.html
@@ -107,7 +107,9 @@ AgentSkill. Default <code>{}</code>.</td>
 <td>string | null</td>
 <td>no</td>
 <td>Overrides the auto-generated prompt when set. Default
-<code>null</code>.</td>
+<code>null</code>. Stored and used at runtime, but not echoed by
+<code>GET /api/v1/personas/{persona_id}</code> — the detail response omits
+it.</td>
 </tr>
 </tbody>
 </table>

--- a/src/persona_agent/api/config.py
+++ b/src/persona_agent/api/config.py
@@ -52,8 +52,14 @@ class ApiConfig(BaseModel):
         llm_config_path: Path to the LLM configuration file.
         mcp_config_path: Path to the MCP service configuration file.
         default_model: Default LLM model to use for agents.
-        openai_api_key: Optional OpenAI API key.
-        openai_api_base: Optional custom OpenAI API base URL.
+        openai_api_key: Optional OpenAI API key. Informational only —
+            ``load_config`` mirrors the matched model's key here, but the
+            active LLM client is built by
+            ``OpenAICompatibleClient.from_config`` from ``llm_config.json``,
+            not from this field.
+        openai_api_base: Optional custom OpenAI API base URL. Same caveat as
+            ``openai_api_key``: populated for inspection, not used to build
+            the client.
         public_base_url: Optional externally reachable API base URL.
     """
 
@@ -182,13 +188,17 @@ def load_config() -> ApiConfig:
             if ENV_DEFAULT_MODEL not in os.environ and "default_model" in llm_config:
                 config.default_model = llm_config["default_model"]
 
-            # Get API keys and settings from model_configs
+            # Mirror the matched model's credentials onto the config for
+            # inspection. These fields are NOT used to build the LLM client:
+            # OpenAICompatibleClient.from_config reads llm_config.json
+            # directly and owns the real api_key (file-first) / api_base
+            # (env-first) cascade. They are surfaced here only so callers can
+            # introspect the resolved model.
             if "model_configs" in llm_config and isinstance(
                 llm_config["model_configs"], list
             ):
                 for model_config in llm_config["model_configs"]:
                     if model_config.get("name") == config.default_model:
-                        # Only use values from the config file if the environment variable is not set
                         if not config.openai_api_key:
                             config.openai_api_key = model_config.get("api_key")
                         if not config.openai_api_base:


### PR DESCRIPTION
## Summary
Correct the changelog's inaccurate LLM credential-cascade description, propagate the accurate field-specific precedence across the docs and comments, and document two previously undocumented details.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Changelog credential wording | "environment overrides winning" | api_key file-first / api_base env-first | Matches shipped `from_config()` and `configuration.html` |
| README / CLAUDE.md / AGENTS.md | api_key precedence only | field-specific precedence + vestigial-field note | Consistency with `configuration.html` |
| `api/config.py` comments | misleading "env var not set" comment | accurate inspection-only note | Comment/docstring only; no logic change |
| `a2a-protocol.html` | (undocumented) | AgentCard `version` "1.0.0" | Distinct from the `0.2.0` API version |
| `persona-schema.html` | (undocumented) | `system_prompt` not echoed by detail GET | Matches `PersonaDetailResponse` |

## Details
### Align LLM credential cascade
- Design/Spec: `docs/configuration.html` is the authoritative cascade reference.
- Implementation notes: api_key = per-model file > file-level > `OPENAI_API_KEY`; api_base = `OPENAI_BASE_URL` / `OPENAI_API_BASE` > per-model > file-level. `ApiConfig.openai_api_key` / `openai_api_base` are populated in `load_config` but not used to build the client.
- Reviewer focus: confirm the precedence wording matches `OpenAICompatibleClient.from_config()` and `tests/test_review_fixes.py`.

### Document undocumented details
- Design/Spec: AgentCard built by `a2a/agent_card.py` (version default "1.0.0"); `PersonaDetailResponse` in `api/models.py` omits `system_prompt`.
- Implementation notes: documentation-only additions.
- Reviewer focus: accuracy of the version and detail-response claims.

## Testing
- `uv run ruff check .` -- All checks passed
- `uv run pytest -q` -- 47 passed
- Manual steps: Not run

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Documentation and comment-only change; no runtime behavior affected (GitNexus detect_changes shows comment-only line overlap; full suite passes) -- low risk.

## Checklist
- [ ] Tests added/updated if needed (N/A -- no behavior change)
- [x] Docs updated if needed
- [x] Backward compatibility considered (no behavior change)
- [x] Rollout/monitoring considerations noted
